### PR TITLE
Flaky fix for org.apache.flink.table.expressions.MapTypeTest

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/MapTypeTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/MapTypeTestBase.scala
@@ -23,26 +23,26 @@ import org.apache.flink.types.Row
 
 import com.google.common.collect.ImmutableMap
 
-import java.util.{HashMap => JHashMap}
+import java.util.{LinkedHashMap => JLinkedHashMap}
 
 abstract class MapTypeTestBase extends ExpressionTestBase {
 
   override def testData: Row = {
-    val map1 = new JHashMap[String, Int]()
+    val map1 = new JLinkedHashMap[String, Int]()
     map1.put("a", 12)
     map1.put("b", 13)
-    val map2 = new JHashMap[Int, String]()
+    val map2 = new JLinkedHashMap[Int, String]()
     map2.put(12, "a")
     map2.put(13, "b")
-    val map3 = new JHashMap[Long, Int]()
+    val map3 = new JLinkedHashMap[Long, Int]()
     map3.put(10L, 1)
     map3.put(20L, 2)
-    val map4 = new JHashMap[Int, Array[Int]]()
+    val map4 = new JLinkedHashMap[Int, Array[Int]]()
     map4.put(1, Array(10, 100))
     map4.put(2, Array(20, 200))
     val testData = new Row(12)
     testData.setField(0, null)
-    testData.setField(1, new JHashMap[String, Int]())
+    testData.setField(1, new JLinkedHashMap[String, Int]())
     testData.setField(2, map1)
     testData.setField(3, map2)
     testData.setField(4, "foo")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Flaky fixes for 2 tests under [org.apache.flink.table.expressions.MapTypeTest](https://github.com/kevin952/flink/blob/7542b56f2abb860f42a83c4687f6e38bb82b78c6/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala)


## Brief change log

The mapping function caused flakiness which changed the order. Hence, a ```LinkedHashMap``` ensured no flakiness in the  code.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
